### PR TITLE
Add private lockable media gallery

### DIFF
--- a/app/Uploads/[userId]/[filename]/route.ts
+++ b/app/Uploads/[userId]/[filename]/route.ts
@@ -1,0 +1,88 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import path from 'path'
+import { createReadStream } from 'fs'
+import { promises as fs } from 'fs'
+
+const UNLOCK_COOKIE_NAME = 'vault_unlocked'
+
+export async function GET(request: NextRequest, context: { params: { userId: string; filename: string } }) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const isUnlocked = request.cookies.get(UNLOCK_COOKIE_NAME)?.value === '1'
+    if (!isUnlocked) {
+      return NextResponse.json({ error: 'Vault locked' }, { status: 423 })
+    }
+
+    const { userId, filename } = context.params
+    if (session.user.id !== userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const item = await prisma.mediaItem.findFirst({
+      where: { userId, storedFilename: filename }
+    })
+    if (!item) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    const filePath = path.join(process.cwd(), 'Uploads', userId, filename)
+    const stat = await fs.stat(filePath)
+    const fileSize = stat.size
+    const range = request.headers.get('range')
+
+    const headers: Record<string, string> = {
+      'Accept-Ranges': 'bytes',
+      'Content-Type': item.mimeType || 'application/octet-stream',
+      'Cache-Control': 'private, no-store'
+    }
+
+    if (range) {
+      const match = /bytes=(\d+)-(\d*)/.exec(range)
+      if (!match) {
+        return NextResponse.json({ error: 'Invalid range' }, { status: 416 })
+      }
+      const start = Number(match[1])
+      const end = match[2] ? Number(match[2]) : fileSize - 1
+      if (start >= fileSize || end >= fileSize) {
+        return new NextResponse(null, {
+          status: 416,
+          headers: {
+            'Content-Range': `bytes */${fileSize}`
+          }
+        })
+      }
+      const chunkSize = end - start + 1
+      const stream = createReadStream(filePath, { start, end })
+      return new NextResponse(stream as any, {
+        status: 206,
+        headers: {
+          ...headers,
+          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+          'Content-Length': String(chunkSize)
+        }
+      })
+    }
+
+    const stream = createReadStream(filePath)
+    return new NextResponse(stream as any, {
+      status: 200,
+      headers: {
+        ...headers,
+        'Content-Length': String(fileSize)
+      }
+    })
+  } catch (error) {
+    console.error('File serve error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+

--- a/app/api/media-vault/passcode/route.ts
+++ b/app/api/media-vault/passcode/route.ts
@@ -1,0 +1,38 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import bcryptjs from 'bcryptjs'
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { passcode } = await request.json()
+    if (!passcode || typeof passcode !== 'string' || passcode.length < 4) {
+      return NextResponse.json({ error: 'Passcode must be at least 4 characters' }, { status: 400 })
+    }
+
+    const passcodeHash = await bcryptjs.hash(passcode, 10)
+
+    // Upsert the user's vault
+    await prisma.mediaVault.upsert({
+      where: { userId: session.user.id },
+      update: { passcodeHash },
+      create: {
+        userId: session.user.id,
+        passcodeHash
+      }
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Vault passcode error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/media-vault/unlock/route.ts
+++ b/app/api/media-vault/unlock/route.ts
@@ -1,0 +1,53 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import bcryptjs from 'bcryptjs'
+
+const UNLOCK_COOKIE_NAME = 'vault_unlocked'
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { passcode } = await request.json()
+    if (!passcode || typeof passcode !== 'string') {
+      return NextResponse.json({ error: 'Invalid passcode' }, { status: 400 })
+    }
+
+    const vault = await prisma.mediaVault.findUnique({ where: { userId: session.user.id } })
+    if (!vault?.passcodeHash) {
+      return NextResponse.json({ error: 'Vault not set up' }, { status: 400 })
+    }
+
+    const valid = await bcryptjs.compare(passcode, vault.passcodeHash)
+    if (!valid) {
+      return NextResponse.json({ error: 'Incorrect passcode' }, { status: 403 })
+    }
+
+    const response = NextResponse.json({ success: true })
+    // Set short-lived cookie marking unlocked; scoped to this app
+    response.cookies.set(UNLOCK_COOKIE_NAME, '1', {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 30, // 30 minutes
+      path: '/'
+    })
+    return response
+  } catch (error) {
+    console.error('Vault unlock error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ success: true })
+  response.cookies.set(UNLOCK_COOKIE_NAME, '', { maxAge: 0, path: '/' })
+  return response
+}

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -1,0 +1,117 @@
+export const dynamic = 'force-dynamic'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/db'
+import { createWriteStream, promises as fs } from 'fs'
+import path from 'path'
+
+const UNLOCK_COOKIE_NAME = 'vault_unlocked'
+const UPLOADS_DIR = path.join(process.cwd(), 'Uploads')
+
+async function ensureUnlocked(request: NextRequest) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const isUnlocked = request.cookies.get(UNLOCK_COOKIE_NAME)?.value === '1'
+  if (!isUnlocked) {
+    return { error: NextResponse.json({ error: 'Vault locked' }, { status: 423 }) }
+  }
+  return { session }
+}
+
+export async function GET(request: NextRequest) {
+  const result = await ensureUnlocked(request)
+  if ('error' in result) return result.error
+  const { session } = result
+
+  const items = await prisma.mediaItem.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' }
+  })
+  return NextResponse.json({ items })
+}
+
+export async function POST(request: NextRequest) {
+  const result = await ensureUnlocked(request)
+  if ('error' in result) return result.error
+  const { session } = result
+
+  try {
+    const contentType = request.headers.get('content-type') || ''
+    if (!contentType.startsWith('multipart/form-data')) {
+      return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 })
+    }
+
+    const formData = await request.formData()
+    const file = formData.get('file') as File | null
+    if (!file) {
+      return NextResponse.json({ error: 'Missing file' }, { status: 400 })
+    }
+
+    await fs.mkdir(UPLOADS_DIR, { recursive: true })
+    const userDir = path.join(UPLOADS_DIR, session.user.id)
+    await fs.mkdir(userDir, { recursive: true })
+
+    const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    const storedFilename = `${Date.now()}_${Math.random().toString(36).slice(2)}_${file.name}`
+    const filePath = path.join(userDir, storedFilename)
+    await fs.writeFile(filePath, buffer)
+
+    const stats = await fs.stat(filePath)
+    const mimeType = file.type || 'application/octet-stream'
+
+    const vault = await prisma.mediaVault.upsert({
+      where: { userId: session.user.id },
+      update: {},
+      create: { userId: session.user.id }
+    })
+
+    const item = await prisma.mediaItem.create({
+      data: {
+        userId: session.user.id,
+        vaultId: vault.id,
+        originalName: file.name,
+        storedFilename,
+        mimeType,
+        fileSizeBytes: Number(stats.size),
+        storagePath: `/Uploads/${session.user.id}/${storedFilename}`
+      }
+    })
+
+    return NextResponse.json({ item })
+  } catch (error) {
+    console.error('Upload error:', error)
+    return NextResponse.json({ error: 'Upload failed' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const result = await ensureUnlocked(request)
+  if ('error' in result) return result.error
+  const { session } = result
+
+  try {
+    const { searchParams } = new URL(request.url)
+    const id = searchParams.get('id')
+    if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+
+    const item = await prisma.mediaItem.findUnique({ where: { id } })
+    if (!item || item.userId !== session.user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    const filePath = path.join(process.cwd(), item.storagePath)
+    await prisma.mediaItem.delete({ where: { id } })
+    await fs.unlink(filePath).catch(() => {})
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Delete error:', error)
+    return NextResponse.json({ error: 'Delete failed' }, { status: 500 })
+  }
+}

--- a/dashboard/dashboard-client.tsx
+++ b/dashboard/dashboard-client.tsx
@@ -24,7 +24,8 @@ import {
   Sparkles,
   Users,
   Eye,
-  BarChart3
+  BarChart3,
+  Image as ImageIcon
 } from 'lucide-react'
 import Link from 'next/link'
 import { format } from 'date-fns'
@@ -107,6 +108,13 @@ export default function DashboardClient({ user, recentSessions, progressData, pr
                     icon: MessageCircle,
                     href: '/dashboard/ai-coach',
                     color: 'from-blue-500 to-cyan-500'
+                  },
+                  {
+                    title: 'Private Gallery',
+                    description: 'Locked media vault for images and videos',
+                    icon: ImageIcon,
+                    href: '/dashboard/gallery',
+                    color: 'from-fuchsia-500 to-pink-500'
                   },
                   {
                     title: 'AI Video Analysis',

--- a/dashboard/gallery/gallery-client.tsx
+++ b/dashboard/gallery/gallery-client.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Badge } from '@/components/ui/badge'
+import { Trash2, Lock, Unlock, Upload, Image as ImageIcon, Video } from 'lucide-react'
+
+interface MediaItem {
+  id: string
+  originalName: string
+  storedFilename: string
+  mimeType: string
+  storagePath: string
+  fileSizeBytes: number
+  createdAt: string
+}
+
+export default function GalleryClient() {
+  const [items, setItems] = useState<MediaItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [unlockOpen, setUnlockOpen] = useState(false)
+  const [passcode, setPasscode] = useState('')
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchItems = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/media', { cache: 'no-store' })
+      if (res.status === 423) {
+        setUnlockOpen(true)
+        setItems([])
+        return
+      }
+      if (!res.ok) throw new Error('Failed to load media')
+      const data = await res.json()
+      setItems(data.items)
+    } catch (e: any) {
+      setError(e.message || 'Failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchItems()
+  }, [])
+
+  const onUnlock = async () => {
+    setError(null)
+    const res = await fetch('/api/media-vault/unlock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ passcode })
+    })
+    if (res.ok) {
+      setUnlockOpen(false)
+      setPasscode('')
+      fetchItems()
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Unlock failed')
+    }
+  }
+
+  const onUploadClick = () => fileInputRef.current?.click()
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const fd = new FormData()
+    fd.append('file', file)
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/media', { method: 'POST', body: fd })
+      if (res.status === 423) {
+        setUnlockOpen(true)
+        return
+      }
+      if (!res.ok) throw new Error('Upload failed')
+      await fetchItems()
+    } catch (e: any) {
+      setError(e.message || 'Upload failed')
+    } finally {
+      setLoading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  const onDelete = async (id: string) => {
+    if (!confirm('Delete this item?')) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/media?id=${encodeURIComponent(id)}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Delete failed')
+      setItems(prev => prev.filter(i => i.id !== id))
+    } catch (e: any) {
+      setError(e.message || 'Delete failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const isVideo = (mime: string) => mime.startsWith('video/') || /mp4|webm|ogg/.test(mime)
+  const isImage = (mime: string) => mime.startsWith('image/') || /gif/.test(mime)
+
+  return (
+    <div className="container-custom py-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold">Private Gallery</h1>
+        <div className="flex items-center gap-3">
+          <Button variant="outline" onClick={fetchItems} disabled={loading}>Refresh</Button>
+          <input ref={fileInputRef} type="file" className="hidden" onChange={onFileChange} />
+          <Button onClick={onUploadClick} disabled={loading}>
+            <Upload className="h-4 w-4 mr-2" /> Upload
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 text-sm text-red-600">{error}</div>
+      )}
+
+      <Card className="bg-white/70 backdrop-blur-sm">
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Lock className="h-5 w-5 mr-2" /> Vault Contents
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No media yet. Upload to get started.</p>
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              {items.map(item => (
+                <div key={item.id} className="group relative border rounded-md overflow-hidden bg-white/80">
+                  <div className="absolute right-2 top-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Button size="icon" variant="destructive" onClick={() => onDelete(item.id)}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <div className="aspect-video w-full bg-gray-100 flex items-center justify-center overflow-hidden">
+                    {isImage(item.mimeType) ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={item.storagePath} alt={item.originalName} className="w-full h-full object-cover" />
+                    ) : isVideo(item.mimeType) ? (
+                      <video src={item.storagePath} className="w-full h-full object-cover" controls />
+                    ) : (
+                      <div className="text-muted-foreground text-sm p-4 text-center">
+                        Unsupported: {item.mimeType}
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-2 text-xs flex items-center justify-between">
+                    <span className="truncate" title={item.originalName}>{item.originalName}</span>
+                    <Badge variant="secondary">{(item.fileSizeBytes / (1024 * 1024)).toFixed(2)} MB</Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={unlockOpen} onOpenChange={setUnlockOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unlock Vault</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Input type="password" placeholder="Enter passcode" value={passcode} onChange={(e) => setPasscode(e.target.value)} />
+            {error && <div className="text-sm text-red-600">{error}</div>}
+          </div>
+          <DialogFooter>
+            <Button onClick={onUnlock} disabled={!passcode}>Unlock</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+

--- a/dashboard/gallery/page.tsx
+++ b/dashboard/gallery/page.tsx
@@ -1,0 +1,10 @@
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
+import { redirect } from 'next/navigation'
+import GalleryClient from './gallery-client'
+
+export default async function GalleryPage() {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) redirect('/auth/signin')
+  return <GalleryClient />
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,8 @@ model User {
   notifications               Notification[]
   feedbackSubmissions         FeedbackSubmission[]
   userPositionRecommendations UserPositionRecommendation[]
+  mediaVault                  MediaVault?
+  mediaItems                  MediaItem[]
 
   @@map("users")
 }
@@ -274,4 +276,42 @@ model FeedbackSubmission {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("feedback_submissions")
+}
+
+// Private, lockable media vault for each user
+model MediaVault {
+  id            String     @id @default(cuid())
+  userId        String     @unique
+  passcodeHash  String?
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  mediaItems MediaItem[]
+
+  @@map("media_vaults")
+}
+
+// Individual media items stored in the vault
+model MediaItem {
+  id               String   @id @default(cuid())
+  userId           String
+  vaultId          String
+  originalName     String
+  storedFilename   String
+  mimeType         String
+  fileSizeBytes    Int
+  widthPixels      Int?
+  heightPixels     Int?
+  durationSeconds  Float?
+  storagePath      String
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  user  User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  vault MediaVault @relation(fields: [vaultId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt])
+  @@index([vaultId])
+  @@map("media_items")
 }


### PR DESCRIPTION
Add a private, lockable media gallery to allow users to securely store and manage their media files.

This PR introduces a new feature for users to upload and store images, videos, and GIFs in a personal, passcode-protected vault. It includes new Prisma models (`MediaVault`, `MediaItem`), API endpoints for vault management (set/update passcode, unlock/lock) and media CRUD operations, a secure file-serving route (`/Uploads/[userId]/[filename]`) with authentication and unlock checks, and a dedicated UI page (`/dashboard/gallery`) with an unlock dialog, upload functionality, and media display. A quick action link is also added to the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9dfd376-6992-451c-8490-a6b5ac9a6292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9dfd376-6992-451c-8490-a6b5ac9a6292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

