### PR TITLE
Investigate supabase database integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,20 @@
+# Database (required)
+# For Supabase, set both pooled (runtime) and direct (migrations) URLs
+DATABASE_URL="postgresql://USER:PASSWORD@POOL_HOST:6543/postgres?sslmode=require&pgbouncer=true&connection_limit=1&schema=public"
+DIRECT_URL="postgresql://USER:PASSWORD@DB_HOST:5432/postgres?sslmode=require&schema=public"
+
+# NextAuth (recommended; required in production)
+NEXTAUTH_SECRET="generate_a_strong_random_secret"
+# If running the app at a non-localhost URL (prod), set this too:
+# NEXTAUTH_URL="https://your-domain.com"
+
+# Optional build/runtime knobs
+NEXT_DIST_DIR=".next"                 # custom Next.js dist dir if desired
+NEXT_OUTPUT_MODE=""                   # set to "export" only if doing static export
+
+# Optional features
+ABACUSAI_API_KEY=""                   # used by /app/api/ai-coach route
+
 # --- Web App Environment ---
 NODE_ENV=development
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,30 @@ NEXT_OUTPUT_MODE=""                   # set to "export" only if doing static exp
 ABACUSAI_API_KEY=""                   # used by /app/api/ai-coach route
 ```
 
+#### Supabase (recommended Postgres setup)
+
+For Supabase, use the pooled connection for your app at runtime and a direct connection for migrations:
+
+```bash
+# Pooled (PgBouncer) — runtime
+DATABASE_URL="postgresql://USER:PASSWORD@POOL_HOST:6543/postgres?sslmode=require&pgbouncer=true&connection_limit=1&schema=public"
+
+# Direct — migrations
+DIRECT_URL="postgresql://USER:PASSWORD@DB_HOST:5432/postgres?sslmode=require&schema=public"
+```
+
+Update Prisma datasource to use `DIRECT_URL` for migrations:
+
+```12:16:/workspace/prisma/schema.prisma
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+    directUrl = env("DIRECT_URL")
+}
+```
+
 Notes:
-- `DATABASE_URL` is consumed by Prisma (`prisma/schema.prisma`).
+- `DATABASE_URL` is consumed by Prisma (`prisma/schema.prisma`). If using Supabase, also set `DIRECT_URL`.
 - `NEXTAUTH_SECRET` is required for production with NextAuth.
 - Keep `NEXT_OUTPUT_MODE` empty for a normal server build. Only set `export` if you understand the static export limitations.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,8 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
+	url      = env("DATABASE_URL")
+	directUrl = env("DIRECT_URL")
 }
 
 model Account {


### PR DESCRIPTION
Enable Supabase as a Postgres backend by configuring Prisma with pooled and direct connection URLs and updating documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc41ebd8-707d-48ab-9ff8-f947b27c09e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc41ebd8-707d-48ab-9ff8-f947b27c09e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

